### PR TITLE
Use proxy information from Windows registry for xidel call

### DIFF
--- a/pint.cmd
+++ b/pint.cmd
@@ -510,7 +510,15 @@ function pint-get-dist-link([Hashtable]$info, $verbose)
 
 		$method = if ($info['method']) {'-d "'+$info['data']+'" --method '+$info['method']} else {''}
 
-		$dist = & $env:ComSpec /d /c "$out xidel $method --header=`"Referer: $dist`" --user-agent=`"$($env:PINT_USER_AGENT)`" `"$dist`" $follow $quiet --extract `"($link)[1]`""
+		$proxyEnabled = (get-itemproperty 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings').ProxyEnable
+		if ($proxyEnabled) {
+			$proxyAddr = (get-itemproperty 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings').ProxyServer
+			$proxy = "--proxy=`"$proxyAddr`""
+		} else {
+			$proxy = ""
+		}
+
+		$dist = & $env:ComSpec /d /c "$out xidel $method $proxy --header=`"Referer: $dist`" --user-agent=`"$($env:PINT_USER_AGENT)`" `"$dist`" $follow $quiet --extract `"($link)[1]`""
 
 		if ($lastexitcode -or !$dist -or !$dist.contains('://')) {
 			$dist = $null


### PR DESCRIPTION
The xidel call was not proxy-aware, so pint was unusable behind a proxy. Now system proxy settings are read from the Windows registry.
This now works if you enter proxy information directly (address, port). PAC files for automated proxy configurations is not respected.