### PR TITLE
Clean proxy address from http:// prefix

### DIFF
--- a/pint.cmd
+++ b/pint.cmd
@@ -512,7 +512,7 @@ function pint-get-dist-link([Hashtable]$info, $verbose)
 
 		$proxyEnabled = (get-itemproperty 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings').ProxyEnable
 		if ($proxyEnabled) {
-			$proxyAddr = (get-itemproperty 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings').ProxyServer
+			$proxyAddr = (get-itemproperty 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings').ProxyServer -replace "^http://", ""
 			$proxy = "--proxy=`"$proxyAddr`""
 		} else {
 			$proxy = ""


### PR DESCRIPTION
New versions of windows automatically put http:// in front of the proxy host name (ProxyServer regedit key). Xidel though expects the plain host name. This regex strips the prefix.